### PR TITLE
Do not forward replies

### DIFF
--- a/linkloop_reply.c
+++ b/linkloop_reply.c
@@ -80,7 +80,11 @@ int main(int argc, char *argv[]) {
 			/* check if this packet has been received on a listened interface */
 			if(memcmp(llr.mac_listen[i], llr.dst_mac, IFHWADDRLEN))
 				continue;
-				
+
+		        /* skip replies */
+			if(rpack.llc.dsap == 0x80) 
+				continue;
+
 			/* return a test packet to the sender */
 			printf("Received packet on %s\n", argv[i+1]);
 			mk_test_packet(&spack, &sll, llr.dst_mac, llr.ifindex_listen[i], llr.src_mac, len, 1);


### PR DESCRIPTION
if linkloop_reply runs both on source and destination host, there is a forwarding loop -> do not forward replies